### PR TITLE
Fixed broken hrefs from uva/index.html to hw1

### DIFF
--- a/uva/index.html
+++ b/uva/index.html
@@ -46,7 +46,7 @@
 <h2 id="homeworks">Homeworks</h2>
 <p>Unless otherwise noted, all submissions are due by the end of the day of the due date given -- this means by 11:59:59 pm. The late policies are discussed in the <a href="hw-policies.html">homework policies page</a> (<a href="hw-policies.md">md</a>). Submission is through the <a href="https://libra.cs.virginia.edu/~pedagogy/submit.php">online submission system</a> -- all submissions should open up 3 days (i.e., 72 hours) prior to the due date/time.</p>
 <ul>
-<li><a href="../../hws/hw-paranoia.html">HW 1: Rational Paranoia</a> (<a href="../../hws/hw-paranoia.md">md</a>) is due Friday, September 6th</li>
+<li><a href="../hws/hw-paranoia.html">HW 1: Rational Paranoia</a> (<a href="../../hws/hw-paranoia.md">md</a>) is due Friday, September 6th</li>
 </ul>
 <h2 id="lecture-progress">Lecture progress</h2>
 <ul>

--- a/uva/index.html
+++ b/uva/index.html
@@ -46,7 +46,7 @@
 <h2 id="homeworks">Homeworks</h2>
 <p>Unless otherwise noted, all submissions are due by the end of the day of the due date given -- this means by 11:59:59 pm. The late policies are discussed in the <a href="hw-policies.html">homework policies page</a> (<a href="hw-policies.md">md</a>). Submission is through the <a href="https://libra.cs.virginia.edu/~pedagogy/submit.php">online submission system</a> -- all submissions should open up 3 days (i.e., 72 hours) prior to the due date/time.</p>
 <ul>
-<li><a href="../hws/hw-paranoia.html">HW 1: Rational Paranoia</a> (<a href="../../hws/hw-paranoia.md">md</a>) is due Friday, September 6th</li>
+<li><a href="../hws/hw-paranoia.html">HW 1: Rational Paranoia</a> (<a href="../hws/hw-paranoia.md">md</a>) is due Friday, September 6th</li>
 </ul>
 <h2 id="lecture-progress">Lecture progress</h2>
 <ul>


### PR DESCRIPTION
The hrefs to the rational paranoia homework html/md pages are broken in the uva/index.html file - I fixed them.